### PR TITLE
Add create_from_url, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ vultrInstance.iso.list().then(function(list) {
 })
 ```
 
+### vultrInstance.iso.createFromUrl
+
+```js
+vultrInstance.iso.createFromUrl().then(function(list) {
+  // Returns Object with ISO upload status
+})
+```
+
 ## Backup
 
 ### vultrInstance.backup.list

--- a/lib/iso.js
+++ b/lib/iso.js
@@ -18,4 +18,23 @@ ISO.prototype.list = function list() {
   return this.vultr.communicate(this.service, 'list');
 };  
 
+/**
+ * Create a new ISO image on the current account.
+ * The ISO image will be downloaded from a given URL.
+ * Download status can be checked with the v1/iso/list call.
+ * @param {String} url Remote URL from where the ISO will be downloaded.
+ * @return {Promise}            Object with data
+ */
+ISO.prototype.createFromUrl = function createFromUrl(url) {
+  if(url === void 0 || url === '') {
+    return Promise.reject(new Error(403));
+  }
+
+  var data = {
+    'url': url
+  };
+
+  return this.vultr.communicate(this.service, 'create_from_url', data);
+};
+
 module.exports = ISO;


### PR DESCRIPTION
I needed this feature and thought I would take a crack at adding it.  Tested with an image and is working. Wasn't sure if a test was appropriate since it adds new ISOs to your account.

```
var url = 'https://cdn.netbsd.org/pub/NetBSD/NetBSD-7.1.1/images/NetBSD-7.1.1-amd64.iso';
vultrInstance.iso.createFromUrl(url).then(function (data) {
  // data
  // { ISOID: 380206 }
});

vultrInstance.iso.list().then(function(list) {
 // list:
 // { '380206':
 //  { ISOID: 380206,
 //    date_created: '2018-02-12 10:37:26',
 //    filename: 'NetBSD-7.1.1-amd64.iso',
 //    size: 0,
 //    md5sum: '',
 //    status: 'pending' } }
});

// few minutes later...

vultrInstance.iso.list().then(function(list) {
  // list:
  // { '380206':
  //  { ISOID: 380206,
  //    date_created: '2018-02-12 10:37:26',
  //    filename: 'NetBSD-7.1.1-amd64.iso',
  //    size: 393820160,
  //    md5sum: '01baf20a3c6c514aaef38020871d971c',
  //    status: 'complete' } }
});
```